### PR TITLE
Fix font-family definition & remove extra padding

### DIFF
--- a/client.js
+++ b/client.js
@@ -14,7 +14,6 @@
       'font-family: Consolas',
       'top: 0',
       'left: 0',
-      'padding: 1rem',
       'opacity: 0.98',
       'box-sizing: border-box',
       'z-index: 2147483647'
@@ -32,7 +31,7 @@
     ],
 
     '.bs-pretty-message__header': [
-      'font-family: "helvetica neue, helvetica, sans-serif',
+      'font-family: "helvetica neue", helvetica, sans-serif',
       'box-sizing: border-box'
     ],
 


### PR DESCRIPTION
I’ve fixed a typo in the font-family definition. I also took the liberty to remove the padding on the container which was spacing the whole notification from the window and therefore adding some scroll due to the 100% height.

WDYT ?