### PR TITLE
Prevent most conflicts with existing styling, fix #22

### DIFF
--- a/client.js
+++ b/client.js
@@ -72,7 +72,7 @@
     var html = [
       '<div class="bs-pretty-message__wrapper">',
       '<h1 class="bs-pretty-message__header">%s</h1>',
-      '<pre class="bs-pretty-message__content" style="white-space:pre-line;">%s</pre>',
+      '<div class="bs-pretty-message__content" style="white-space:pre-line;">%s</div>',
       '</div>'
     ].join('')
 


### PR DESCRIPTION
This is an attempt to fix #22.

I was about to add some extra styles to reset properties on this element but this could lead to a pretty long list (margin, padding, background, border, text-shadow, box-shadow, …) to override.

I thought it would be much simpler to use a `div` instead of the `pre` since those usually don’t have any default style applied. In my case it fix the issue but maybe you want to be more defensive around this?